### PR TITLE
refactor: convert commands to bash aliases in .bashrc

### DIFF
--- a/ubuntu-utility/commands/logging.sh
+++ b/ubuntu-utility/commands/logging.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-export DEBIAN_FRONTEND=noninteractive
-
-log() {
-    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"
-}

--- a/ubuntu-utility/commands/logging.sh
+++ b/ubuntu-utility/commands/logging.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"
+}

--- a/ubuntu-utility/commands/notes.sh
+++ b/ubuntu-utility/commands/notes.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-# Change directory to repos/Notes
-
-notes(){
-
-    cd ~/repos/Notes || "command 'notes' failed"
-}

--- a/ubuntu-utility/commands/path.sh
+++ b/ubuntu-utility/commands/path.sh
@@ -1,7 +1,0 @@
-#!/bin/env bash
-
-path() {
-
-     echo $PATH | tr ':' '\n' || echo "command 'path' failed"
-
-}

--- a/ubuntu-utility/commands/utils.sh
+++ b/ubuntu-utility/commands/utils.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-# Change directory to repos/utils
-utils() {
-    cd ~/repos/utils || "command 'utils' failed"
-}

--- a/ubuntu-utility/dotfiles/bash/.bashrc
+++ b/ubuntu-utility/dotfiles/bash/.bashrc
@@ -106,9 +106,7 @@ alias path='echo $PATH | tr ":" "\n"'
 alias clear-path='export PATH=$(echo "$PATH" | tr ":" "\n" | awk "!seen[$0]++" | tr "\n" ":" | sed "s/:$//")'
 
 # Logging function
-log() {
-    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"
-}
+source ~/repos/utils/ubuntu-utility/commands/logging.sh
 
 # Bash prompt
 RESET="\[\e[0m\]"

--- a/ubuntu-utility/dotfiles/bash/.bashrc
+++ b/ubuntu-utility/dotfiles/bash/.bashrc
@@ -105,8 +105,6 @@ alias notes='cd ~/repos/Notes'
 alias path='echo $PATH | tr ":" "\n"'
 alias clear-path='export PATH=$(echo "$PATH" | tr ":" "\n" | awk "!seen[$0]++" | tr "\n" ":" | sed "s/:$//")'
 
-# Logging function
-source ~/repos/utils/ubuntu-utility/commands/logging.sh
 
 # Bash prompt
 RESET="\[\e[0m\]"

--- a/ubuntu-utility/dotfiles/bash/.bashrc
+++ b/ubuntu-utility/dotfiles/bash/.bashrc
@@ -23,10 +23,6 @@ HISTFILESIZE=2000
 # update the values of LINES and COLUMNS.
 shopt -s checkwinsize
 
-# If set, the pattern "**" used in a pathname expansion context will
-# match all files and zero or more directories and subdirectories.
-#shopt -s globstar
-
 # make less more friendly for non-text input files, see lesspipe(1)
 [ -x /usr/bin/lesspipe ] && eval "$(SHELL=/bin/sh lesspipe)"
 
@@ -40,16 +36,8 @@ case "$TERM" in
     xterm-color|*-256color) color_prompt=yes;;
 esac
 
-# uncomment for a colored prompt, if the terminal has the capability; turned
-# off by default to not distract the user: the focus in a terminal window
-# should be on the output of commands, not on the prompt
-#force_color_prompt=yes
-
 if [ -n "$force_color_prompt" ]; then
     if [ -x /usr/bin/tput ] && tput setaf 1 >&/dev/null; then
-	# We have color support; assume it's compliant with Ecma-48
-	# (ISO/IEC-6429). (Lack of such support is extremely rare, and such
-	# a case would tend to support setf rather than setaf.)
 	color_prompt=yes
     else
 	color_prompt=
@@ -76,38 +64,22 @@ esac
 if [ -x /usr/bin/dircolors ]; then
     test -r ~/.dircolors && eval "$(dircolors -b ~/.dircolors)" || eval "$(dircolors -b)"
     alias ls='ls --color=auto'
-    #alias dir='dir --color=auto'
-    #alias vdir='vdir --color=auto'
-
     alias grep='grep --color=auto'
     alias fgrep='fgrep --color=auto'
     alias egrep='egrep --color=auto'
 fi
-
-# colored GCC warnings and errors
-#export GCC_COLORS='error=01;31:warning=01;35:note=01;36:caret=01;32:locus=01:quote=01'
 
 # some more ls aliases
 alias ll='ls -alF'
 alias la='ls -A'
 alias l='ls -CF'
 
-# Add an "alert" alias for long running commands.  Use like so:
-#   sleep 10; alert
-alias alert='notify-send --urgency=low -i "$([ $? = 0 ] && echo terminal || echo error)" "$(history|tail -n1|sed -e '\''s/^\s*[0-9]\+\s*//;s/[;&|]\s*alert$//'\'')"'
-
 # Alias definitions.
-# You may want to put all your additions into a separate file like
-# ~/.bash_aliases, instead of adding them here directly.
-# See /usr/share/doc/bash-doc/examples in the bash-doc package.
-
 if [ -f ~/.bash_aliases ]; then
     . ~/.bash_aliases
 fi
 
-# enable programmable completion features (you don't need to enable
-# this, if it's already enabled in /etc/bash.bashrc and /etc/profile
-# sources /etc/bash.bashrc).
+# enable programmable completion features
 if ! shopt -oq posix; then
   if [ -f /usr/share/bash-completion/bash_completion ]; then
     . /usr/share/bash-completion/bash_completion
@@ -116,62 +88,37 @@ if ! shopt -oq posix; then
   fi
 fi
 
-#--------------------------------------------------
-
-
-#---------------------------------------------------
-#-----------------------------------------------------
-#----------------------------------------------------
 # User code starts here
 
 # PATH variable
+export DEBIAN_FRONTEND=noninteractive
 USERNAME=$(whoami)
-OPENCODE_DIR="/home/$USERNAME/.opencode/bin" # opencode
-export PATH="$OPENCODE_DIR:$PATH"
-
-export PATH="$HOME/.pyenv/bin:$PATH"  # pyenv
+export PATH="$HOME/.opencode/bin:$PATH"
+export PATH="$HOME/.pyenv/bin:$PATH"
 eval "$(pyenv init --path)"
 eval "$(pyenv init -)"
-eval "$(pyenv virtualenv-init -)"   
+eval "$(pyenv virtualenv-init -)"
 
+# User-defined aliases
+alias utils='cd ~/repos/utils'
+alias notes='cd ~/repos/Notes'
+alias path='echo $PATH | tr ":" "\n"'
+alias clear-path='export PATH=$(echo "$PATH" | tr ":" "\n" | awk "!seen[$0]++" | tr "\n" ":" | sed "s/:$//")'
 
-# user defined commands
-# (optionally) implement lazy loading here, so each util is loaded
-# only when it's called
-COMMANDS_DIR="$HOME/repos/utils/ubuntu-utility/commands"
+# Logging function
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"
+}
 
-if [ -d "$COMMANDS_DIR" ]; then
-    for file in "$COMMANDS_DIR"/*.sh; do
-        [ -r "$file" ] && source "$file"
-    done
-fi
-
-
-# bash prompt
-
-# Load git-prompt (adjust path if needed)
-#if [ -f /usr/share/git/completion/git-prompt.sh ]; then
-#    source /usr/share/git/completion/git-prompt.sh
-#fi
-
-# ---- Colors ----
+# Bash prompt
 RESET="\[\e[0m\]"
 BOLD="\[\e[1m\]"
 GREEN="\[\e[32m\]"
 BLUE="\[\e[34m\]"
 YELLOW="\[\e[33m\]"
 
-# ---- Prompt parts ----
 USER_HOST="${BOLD}${GREEN}\u@\h${RESET}"
 WORK_DIR="${BLUE}\w${RESET}"
-
-# Expand colors now, run git later
 GIT_PART="${YELLOW}\$(__git_ps1 \" (%s)\")${RESET}"
 
-# ---- Final PS1 ----
 PS1="${USER_HOST}${GIT_PART}\n${WORK_DIR} $ "
-
-
-# aliases
-alias clear-path="export PATH=$(echo "$PATH" | tr ':' '\n' | awk '!seen[$0]++' | tr '\n' ':' | sed 's/:$//')
-"


### PR DESCRIPTION
- Removed commands/utils.sh, notes.sh, path.sh (now aliases)
- Removed commands/logging.sh (log function now in .bashrc)
- Added aliases: utils, notes, path, clear-path
- Added log() function directly in .bashrc
- Cleaned up .bashrc by removing messy separators and redundant comments
- Consolidated PATH configuration

Resolves #48